### PR TITLE
update ruby from 2.5 to 2.5.7 docker compose

### DIFF
--- a/2020_s1/bootstrap/Dockerfile
+++ b/2020_s1/bootstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5.7
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
 RUN mkdir /myapp
 WORKDIR /myapp


### PR DESCRIPTION
`FROM ruby:2.5` now will pull 2.5.8 which will result in an error when doing `bundle install`